### PR TITLE
Feat: Make Requisitante and Obra fields optional

### DIFF
--- a/js/detalhe-produto.js
+++ b/js/detalhe-produto.js
@@ -108,8 +108,8 @@ import { db } from './firebase-config.js';
         </div>
         <input type="number" id="baixa-quantidade" placeholder="Quantidade (${product.un})" step="any" class="form-control" required>
         ${medidaFieldHtml}
-        <input type="text" id="baixa-requisitante" placeholder="Requisitante" class="form-control" required>
-        <select id="baixa-obra" class="form-control" required>${obrasOptions}</select>
+        <input type="text" id="baixa-requisitante" placeholder="Requisitante" class="form-control">
+        <select id="baixa-obra" class="form-control">${obrasOptions}</select>
         <select id="baixa-tipo-saida" class="form-control" required>${tiposSaidaOptions}</select>
         <input type="text" id="baixa-observacao" placeholder="Observação" class="form-control">
     `;


### PR DESCRIPTION
This change makes the "Requisitante" (Requester) and "Obra" (Work/Project) fields optional in the stock issue form.

This improves the workflow by not forcing you to enter information that may not be necessary or available at the time of the stock issue, making the process faster and more flexible.

The change was implemented by removing the `required` HTML attribute from the corresponding `input` and `select` elements in the dynamically generated form within `js/detalhe-produto.js`.