### PR TITLE
feat: Inclui imposto ST do fornecedor no cálculo de custo

### DIFF
--- a/js/consultas.js
+++ b/js/consultas.js
@@ -86,8 +86,19 @@ document.addEventListener('DOMContentLoaded', async function() {
             let totalCost = 0;
             let totalQuantityForAvg = 0;
             entryMovements.forEach(m => {
-                if (!m.medida || m.medida.trim() === '') {
-                    const entryTotalValue = (m.quantidade * m.valor_unitario) + (m.icms || 0) + (m.ipi || 0) + (m.frete || 0);
+                if ((!m.medida || m.medida.trim() === '') && m.quantidade > 0) {
+                    let entryTotalValue = 0;
+
+                    // Se o novo campo 'custo_total_entrada' existir, use-o
+                    if (m.custo_total_entrada !== undefined) {
+                        entryTotalValue = m.custo_total_entrada;
+                    } else {
+                        // Senão, calcule da forma antiga (fallback para dados legados)
+                        const valorUnit = m.valor_unitario || 0;
+                        const qtdCompra = m.quantidade_compra || m.quantidade; // Usa qtd_compra se existir
+                        entryTotalValue = (qtdCompra * valorUnit) + (m.icms || 0) + (m.ipi || 0) + (m.frete || 0);
+                    }
+
                     totalCost += entryTotalValue;
                     totalQuantityForAvg += m.quantidade;
                 }


### PR DESCRIPTION
Ajusta a lógica de cálculo de custo da entrada para incluir o percentual de Imposto (ST) cadastrado no fornecedor.

- Em `js/movimentacoes.js`:
  - Os dados dos fornecedores agora são carregados na inicialização.
  - A transação de entrada calcula o custo total, aplica o percentual de ST do fornecedor, e salva o resultado no novo campo `custo_total_entrada` na movimentação.
  - A tabela de histórico de movimentações passa a usar o `custo_total_entrada` para calcular o custo unitário, com fallback para o método antigo.

- Em `js/consultas.js`:
  - O cálculo do valor médio e do valor total do estoque foi atualizado para utilizar prioritariamente o novo campo `custo_total_entrada`.
  - Isso garante que o custo com imposto seja refletido nas consultas, mantendo compatibilidade com registros antigos.