### PR TITLE
refactor: Remove o campo 'Código Global' da aplicação

### DIFF
--- a/consultas.html
+++ b/consultas.html
@@ -41,7 +41,6 @@
                             <thead>
                                 <tr>
                                     <th>Código</th>
-                                    <th>Cód. Global</th>
                                     <th>Descrição</th>
                                     <th>Estoque Atual</th>
                                     <th>UN</th>

--- a/js/consultas.js
+++ b/js/consultas.js
@@ -136,7 +136,6 @@ document.addEventListener('DOMContentLoaded', async function() {
             row.className = 'main-row';
             row.innerHTML = `
                 <td>${item.codigo}</td>
-                <td>${item.codigo_global}</td>
                 <td>${item.descricao}</td>
                 <td>${item.estoque || 0}</td>
                 <td>${item.un}</td>

--- a/js/detalhe-produto.js
+++ b/js/detalhe-produto.js
@@ -55,7 +55,6 @@ import { db } from './firebase-config.js';
 
             detailsContainer.innerHTML = `
                 <p><strong>Código:</strong> ${product.codigo}</p>
-                <p><strong>Cód. Global:</strong> ${product.codigo_global || '-'}</p>
                 <p><strong>Descrição:</strong> ${product.descricao}</p>
         <p><strong>Cor:</strong> ${product.cor || '-'}</p>
                 <hr>
@@ -100,7 +99,6 @@ import { db } from './firebase-config.js';
             <p style="margin: 0 0 8px 0;"><strong>Produto:</strong> ${product.descricao}</p>
             <p style="margin: 0 0 8px 0; font-size: 0.9em; color: #A0A0B9;">
                 <span style="margin-right: 15px;"><strong>Código:</strong> ${product.codigo}</span>
-                <span><strong>Cód. Padrão:</strong> ${product.codigo_global || '-'}</span>
             </p>
             <p style="margin: 0; font-size: 0.9em; color: #A0A0B9;">
                 <span style="margin-right: 15px;"><strong>Estoque:</strong> ${estoqueAtual} ${product.un}</span>

--- a/js/etiquetas.js
+++ b/js/etiquetas.js
@@ -48,10 +48,6 @@ function processarEtiquetas() {
                         <div class="header">CÓDIGO</div>
                         <div class="valor">${pData.codigo || ''}</div>
                     </div>
-                    <div class="info-bloco codigo-padrao">
-                        <div class="header">C. PADRÃO</div>
-                        <div class="valor">${pData.codigo_global || ''}</div>
-                    </div>
                 </div>
             </div>
             <div class="etiqueta-footer">

--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -337,7 +337,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         productsSnapshot.forEach(doc => {
              const product = doc.data();
              productsMap[doc.id] = { id: doc.id, ...product };
-             const optionText = `${product.codigo || 'S/C'} - ${product.descricao || 'N/A'} ${product.codigo_global ? '('+product.codigo_global+')' : ''}`.trim();
+             const optionText = `${product.codigo || 'S/C'} - ${product.descricao || 'N/A'}`.trim();
              productSelect.innerHTML += `<option value="${doc.id}">${optionText}</option>`;
         });
 
@@ -372,7 +372,6 @@ document.addEventListener('DOMContentLoaded', async function() {
         const product = productsMap[productId];
 
         document.getElementById('mov-codigo-display').textContent = product ? product.codigo : '-';
-        document.getElementById('mov-codigoglobal-display').textContent = product ? (product.codigo_global || '-') : '-';
         document.getElementById('mov-descricao-display').textContent = product ? product.descricao : '-';
         document.getElementById('mov-un-display').textContent = product ? product.un : '-';
         document.getElementById('mov-estoque-display').textContent = product ? (product.estoque || 0) : '-';
@@ -402,7 +401,6 @@ document.addEventListener('DOMContentLoaded', async function() {
                     data: mov.data ? new Date(mov.data.seconds * 1000).toLocaleString('pt-BR') : '',
                     tipo: mov.tipo || '',
                     codigo: product.codigo || '',
-                    codigo_global: product.codigo_global || '',
                     descricao: product.descricao || '',
                     un: product.un || '',
                     quantidade: mov.quantidade?.toString() || '',
@@ -467,7 +465,6 @@ document.addEventListener('DOMContentLoaded', async function() {
                 <td>${searchData.data}</td>
                 <td class="${searchData.tipo}">${searchData.tipo.toUpperCase()}</td>
                 <td>${searchData.codigo || 'N/A'}</td>
-                <td>${searchData.codigo_global || '-'}</td>
                 <td>${searchData.descricao || 'Produto não encontrado'}</td>
                 <td>${searchData.un || 'N/A'}</td>
                 <td>${searchData.quantidade}</td>

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -83,7 +83,6 @@ document.addEventListener('DOMContentLoaded', async function() {
 
         const product = {
             codigo: document.getElementById('produto-codigo').value,
-            codigo_global: document.getElementById('produto-codigo_global').value,
             descricao: document.getElementById('produto-descricao').value,
             un: document.getElementById('produto-un').value,
             cor: document.getElementById('produto-cor').value,
@@ -126,7 +125,6 @@ document.addEventListener('DOMContentLoaded', async function() {
 
             row.innerHTML = `
                 <td>${pData.codigo}</td>
-                <td>${pData.codigo_global}</td>
                 <td>${pData.descricao}</td>
                 <td>${pData.un}</td>
                 <td>${pData.cor}</td>
@@ -160,7 +158,6 @@ document.addEventListener('DOMContentLoaded', async function() {
             if (product) {
                 document.getElementById('produto-id').value = product.id;
                 document.getElementById('produto-codigo').value = product.data.codigo;
-                document.getElementById('produto-codigo_global').value = product.data.codigo_global;
                 document.getElementById('produto-descricao').value = product.data.descricao;
                 document.getElementById('produto-un').value = product.data.un;
                 document.getElementById('produto-cor').value = product.data.cor;
@@ -295,7 +292,7 @@ async function exportarModeloExcel() {
         });
 
         // 4. Criar a aba principal de "Produtos"
-        const headers = ["codigo", "codigo_global", "descricao", "un", "cor", "fornecedor_nome", "grupo_nome", "aplicacao_nome", "conjunto_nome", "enderecamento_codigo", "conversao_nome_regra"];
+        const headers = ["codigo", "descricao", "un", "cor", "fornecedor_nome", "grupo_nome", "aplicacao_nome", "conjunto_nome", "enderecamento_codigo", "conversao_nome_regra"];
         const mainSheet = XLSX.utils.json_to_sheet([{}], { header: headers });
 
         // 5. Adicionar a "Validação de Dados" (Dropdowns)
@@ -398,7 +395,6 @@ async function handleFileImport(event) {
 
                 const product = {
                     codigo: row.codigo,
-                    codigo_global: row.codigo_global || "",
                     descricao: row.descricao,
                     un: row.un || "",
                     cor: row.cor || "",

--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -47,7 +47,6 @@
                             <select id="mov-produto" required class="form-control" style="grid-column: 1 / -1;"><option value="">Selecione o Produto...</option></select>
 
                             <p class="auto-filled-field"><strong>Código:</strong> <span id="mov-codigo-display">-</span></p>
-                            <p class="auto-filled-field"><strong>Cód. Padrão:</strong> <span id="mov-codigoglobal-display">-</span></p>
                             <p class="auto-filled-field"><strong>Descrição:</strong> <span id="mov-descricao-display">-</span></p>
                             <p class="auto-filled-field" id="mov-un-display-wrapper"><strong>UN:</strong> <span id="mov-un-display">-</span></p>
 
@@ -80,7 +79,6 @@
                         <input type="text" class="form-control filter-input" data-column="data" placeholder="Filtrar por Data...">
                         <input type="text" class="form-control filter-input" data-column="tipo" placeholder="Filtrar por Tipo...">
                         <input type="text" class="form-control filter-input" data-column="codigo" placeholder="Filtrar por Código...">
-                        <input type="text" class="form-control filter-input" data-column="codigo_global" placeholder="Filtrar por Cód. Padrão...">
                         <input type="text" class="form-control filter-input" data-column="descricao" placeholder="Filtrar por Descrição...">
                         <input type="text" class="form-control filter-input" data-column="quantidade" placeholder="Filtrar por Qtde...">
                         <input type="text" class="form-control filter-input" data-column="nf" placeholder="Filtrar por NF...">
@@ -94,7 +92,6 @@
                                     <th data-column="data">Data</th>
                                     <th data-column="tipo">Tipo</th>
                                     <th data-column="codigo">Código</th>
-                                    <th data-column="codigo_global">Cód. Padrão</th>
                                     <th data-column="descricao">Descrição</th>
                                     <th data-column="un">UN</th>
                                     <th data-column="quantidade">Qtde</th>

--- a/produtos.html
+++ b/produtos.html
@@ -33,7 +33,6 @@
                     <form id="form-produto" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 15px;">
                         <input type="hidden" id="produto-id">
                         <input type="text" id="produto-codigo" placeholder="Código" required class="form-control">
-                        <input type="text" id="produto-codigo_global" placeholder="Código Global" class="form-control">
                         <input type="text" id="produto-descricao" placeholder="Descrição" required class="form-control">
                         <input type="text" id="produto-un" placeholder="UN Estoque" required class="form-control">
                         <input type="text" id="produto-cor" placeholder="Cor" class="form-control">
@@ -69,7 +68,6 @@
                             <thead>
                                 <tr>
                                     <th>Código</th>
-                                    <th>Cód. Global</th>
                                     <th>Descrição</th>
                                     <th>UN</th>
                                     <th>Cor</th>


### PR DESCRIPTION
Remove completamente o campo `codigo_global` e toda a sua lógica associada da aplicação, simplificando o modelo de dados do produto e limpando a interface do usuário.

- **Página de Produtos (`produtos.html`, `js/produtos.js`):**
  - Campo removido do formulário de cadastro/edição.
  - Coluna removida da tabela de listagem.
  - Lógica de salvamento, edição, exportação e importação via Excel ajustada para não considerar mais o campo.

- **Página de Movimentações (`movimentacoes.html`, `js/movimentacoes.js`):**
  - Removido da exibição de informações do produto.
  - Removido do texto de seleção de produtos no dropdown.
  - Coluna e filtro removidos da tabela de histórico.

- **Página de Consultas (`consultas.html`, `js/consultas.js`):**
  - Coluna removida da tabela de consulta de estoque.

- **Página de Detalhes e Etiquetas (`js/detalhe-produto.js`, `js/etiquetas.js`):**
  - Removido da tela de detalhes do produto.
  - Removido do modal de baixa de estoque.
  - Removido do layout de impressão da etiqueta.