### PR TITLE
fix: Make "Listar Itens" button visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -134,6 +134,10 @@ body {
     cursor: pointer;
 }
 
+.btn-primary {
+    background-color: #0d6efd;
+}
+
 .btn-success {
     background-color: #198754;
 }

--- a/implementacao.html
+++ b/implementacao.html
@@ -68,7 +68,7 @@
                             <label for="end-address">Endereçamento Final</label>
                             <input type="text" id="end-address" class="form-control" placeholder="Ex: 10-C-20-B">
                         </div>
-                        <button id="btn-list-items" class="btn">Listar Itens</button>
+                        <button id="btn-list-items" class="btn btn-primary">Listar Itens</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
The "Listar Itens" button was invisible because it had white text on a white background. This commit adds a `btn-primary` class to the button to give it a blue background, making it visible.