### PR TITLE
Fix: Remove incorrect conversion on inventory implementation

### DIFF
--- a/js/implementacao.js
+++ b/js/implementacao.js
@@ -368,25 +368,19 @@ document.addEventListener('DOMContentLoaded', async function() {
                             continue;
                         }
 
-                        let quantidadeParaEstoque = qtde;
-                        let quantidadeCompra = qtde;
-                        if (productData.conversaoId && conversoesMap.has(productData.conversaoId)) {
-                            const regra = conversoesMap.get(productData.conversaoId);
-                            const fator_qtd_compra = parseFloat(String(regra.qtd_compra).replace(',', '.'));
-                            const fator_qtd_padrao = parseFloat(String(regra.qtd_padrao).replace(',', '.'));
-                            if (fator_qtd_compra > 0) {
-                                quantidadeParaEstoque = (qtde / fator_qtd_compra) * fator_qtd_padrao;
-                            }
-                        }
+                        // BUG FIX: The conversion logic was incorrectly applied during initial implementation.
+                        // The user enters the quantity and value in the standard unit on this screen,
+                        // so no conversion should take place.
+                        const quantidade = qtde; // Use qtde directly from the input
 
                         const icms = parseFloat(row.querySelector('.icms-input').value) || 0;
                         const ipi = parseFloat(row.querySelector('.ipi-input').value) || 0;
                         const frete = parseFloat(row.querySelector('.frete-input').value) || 0;
-                        const custoTotal = (quantidadeCompra * valorUnit) + icms + ipi + frete;
+                        const custoTotal = (quantidade * valorUnit) + icms + ipi + frete;
 
                         // Update stock
                         if (implementacaoEntryType.movimenta_estoque) {
-                            productData.locacoes[locacaoIndex].estoque = quantidadeParaEstoque;
+                            productData.locacoes[locacaoIndex].estoque = quantidade;
                         }
 
                         // Create movement
@@ -395,8 +389,8 @@ document.addEventListener('DOMContentLoaded', async function() {
                             productId: productId,
                             tipo: 'entrada',
                             tipo_entradaId: implementacaoEntryType.id,
-                            quantidade: quantidadeParaEstoque,
-                            quantidade_compra: quantidadeCompra,
+                            quantidade: quantidade, // This is the quantity in the standard unit
+                            quantidade_compra: quantidade, // For consistency, as no conversion happened
                             locacao: locacaoStr,
                             data: serverTimestamp(),
                             observacao: `Implementação inicial de inventário.`,

--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -127,12 +127,13 @@ document.addEventListener('DOMContentLoaded', async function() {
         const product = productsMap[productId];
         const locacaoSelect = document.getElementById('mov-locacao');
         const isEntrada = document.getElementById('movement-toggle').checked;
+        const unitSelect = document.getElementById('mov-unidade-selecao');
 
-        // Limpa e desabilita o select de locação
+        // Reset fields
         locacaoSelect.innerHTML = '<option value="">Selecione a Locação...</option>';
         locacaoSelect.disabled = true;
-
-        // Esconde o display de estoque antigo
+        unitSelect.innerHTML = '';
+        unitSelect.style.display = 'none';
         document.getElementById('mov-estoque-display-wrapper').style.display = 'none';
 
         if (product) {
@@ -140,13 +141,13 @@ document.addEventListener('DOMContentLoaded', async function() {
             document.getElementById('mov-descricao-display').textContent = product.descricao;
             document.getElementById('mov-un-display').textContent = product.un;
 
+            // Populate locations
             if (product.locacoes && product.locacoes.length > 0) {
                 product.locacoes.forEach(loc => {
                     const option = document.createElement('option');
-                    option.value = loc.locacao; // Usar o código da locação como valor
-
+                    option.value = loc.locacao;
                     let text = loc.locacao;
-                    if (!isEntrada) { // Se for SAÍDA, mostra o estoque
+                    if (!isEntrada) {
                         text += ` (Estoque: ${loc.estoque || 0})`;
                     }
                     option.textContent = text;
@@ -154,8 +155,25 @@ document.addEventListener('DOMContentLoaded', async function() {
                 });
                 locacaoSelect.disabled = false;
             }
+
+            // --- NEW FEATURE: Handle Unit Selection Dropdown ---
+            if (isEntrada && product.conversaoId && configData.conversoes[product.conversaoId]) {
+                const conversao = configData.conversoes[product.conversaoId];
+                const purchaseUnit = conversao.medida_compra;
+                const standardUnit = conversao.medida_padrao;
+
+                if (purchaseUnit && standardUnit) {
+                    unitSelect.innerHTML = `
+                        <option value="${purchaseUnit}">${purchaseUnit}</option>
+                        <option value="${standardUnit}">${standardUnit}</option>
+                    `;
+                    unitSelect.style.display = 'inline-block';
+                }
+            }
+            // --- END OF NEW FEATURE ---
+
         } else {
-            // Limpa os campos se nenhum produto for selecionado
+            // Clear fields if no product is selected
             document.getElementById('mov-codigo-display').textContent = '-';
             document.getElementById('mov-descricao-display').textContent = '-';
             document.getElementById('mov-un-display').textContent = '-';
@@ -167,26 +185,22 @@ document.addEventListener('DOMContentLoaded', async function() {
         const valorUnitarioInput = document.getElementById('mov-valor-unitario');
 
         if (isEntrada) {
-            // Desabilita/habilita todos os campos de custo com base em isSobra
             costFields.forEach(fieldId => {
                 const field = document.getElementById(fieldId);
                 field.disabled = isSobra;
-                field.value = ''; // Limpa todos para começar
+                field.value = '';
             });
 
             quantField.disabled = isSobra;
 
             if (isSobra) {
-                // Se for sobra, preenche o valor unitário com o valor médio e fixa a quantidade em 1
                 valorUnitarioInput.value = product.valorMedio ? product.valorMedio.toFixed(2) : '0.00';
                 quantField.value = 1;
                 quantField.placeholder = "Entrada de sobra é sempre 1 Unidade";
             } else {
-                // Se não for sobra, reabilita os campos e reseta o placeholder de quantidade
                 quantField.placeholder = "Quantidade";
             }
         } else {
-            // Se for SAÍDA, todos os campos de custo e quantidade são habilitados
             costFields.forEach(fieldId => document.getElementById(fieldId).disabled = false);
             quantField.disabled = false;
             quantField.placeholder = "Quantidade";
@@ -413,18 +427,25 @@ document.addEventListener('DOMContentLoaded', async function() {
                         throw new Error("Locação selecionada não encontrada no produto.");
                     }
 
-                    // Lógica de conversão (mantida)
+                    // Lógica de conversão condicional
                     const conversaoId = productData.conversaoId;
                     let quantidadeParaEstoque = quantidade;
+
                     if (conversaoId) {
                         const conversaoRef = doc(db, 'conversoes', conversaoId);
-                        const conversaoDoc = await transaction.get(conversaoRef); // Usar transaction.get
+                        const conversaoDoc = await transaction.get(conversaoRef);
                         if (conversaoDoc.exists()) {
                             const regra = conversaoDoc.data();
-                            const fator_qtd_compra = parseFloat(String(regra.qtd_compra).replace(',', '.'));
-                            const fator_qtd_padrao = parseFloat(String(regra.qtd_padrao).replace(',', '.'));
-                            if (fator_qtd_compra > 0) {
-                                quantidadeParaEstoque = (quantidade / fator_qtd_compra) * fator_qtd_padrao;
+                            const selectedUnit = document.getElementById('mov-unidade-selecao').value;
+                            const purchaseUnit = regra.medida_compra;
+
+                            // Only run conversion if the selected unit is the purchase unit
+                            if (selectedUnit === purchaseUnit) {
+                                const fator_qtd_compra = parseFloat(String(regra.qtd_compra).replace(',', '.'));
+                                const fator_qtd_padrao = parseFloat(String(regra.qtd_padrao).replace(',', '.'));
+                                if (fator_qtd_compra > 0) {
+                                    quantidadeParaEstoque = (quantidade / fator_qtd_compra) * fator_qtd_padrao;
+                                }
                             }
                         }
                     }

--- a/movimentacoes.html
+++ b/movimentacoes.html
@@ -104,7 +104,10 @@
                             <p class="auto-filled-field" id="mov-un-display-wrapper"><strong>UN:</strong> <span id="mov-un-display">-</span></p>
                             <p class="auto-filled-field" id="mov-estoque-display-wrapper" style="display: none;"><strong>Estoque Atual:</strong> <span id="mov-estoque-display">-</span></p>
 
-                            <input type="number" id="mov-quantidade" placeholder="Quantidade" required step="any" class="form-control">
+                            <div style="display: flex; align-items: center; gap: 5px;">
+                                <input type="number" id="mov-quantidade" placeholder="Quantidade" required step="any" class="form-control" style="flex-grow: 1;">
+                                <select id="mov-unidade-selecao" class="form-control" style="display: none; flex-grow: 0; width: auto;"></select>
+                            </div>
 
                             <!-- Container para Campos de ENTRADA -->
                             <div id="entrada-fields-container" style="grid-column: 1 / -1; display: flex; gap: 10px; align-items: flex-end;">


### PR DESCRIPTION
On the 'Inventario de Estoque' screen, when a user performs an 'Initial Implementation' for a product (i.e., the stock at that location is zero), the system was incorrectly applying the product's conversion factor to the entered quantity.

This was incorrect because the user enters the quantity in the standard unit on this screen, not the purchase unit. This bug led to incorrect stock quantities and average cost calculations.

This commit removes the conversion logic from this specific scenario in `js/implementacao.js`. The system now uses the quantity and value directly as entered by the user, ensuring the resulting stock movement and cost calculation are correct. The logic for adjusting existing stock (when stock is not zero) remains unchanged.