### PR TITLE
Fix: Save and display correct unit for manual entries

### DIFF
--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -242,7 +242,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             }
 
             const quantidadeDisplay = isXmlImport ? mov.quantidade_compra : mov.quantidade;
-            const unidadeDisplay = isXmlImport ? mov.un_compra : product.un;
+            const unidadeDisplay = mov.un_compra || product.un;
 
             const processedMov = {
                 ...mov,
@@ -466,11 +466,13 @@ document.addEventListener('DOMContentLoaded', async function() {
                     let custoTotalEntrada = (quantidade * valorUnitario) + icms + ipi + frete;
 
                     // Criação do documento de movimentação
+                    const selectedUnit = document.getElementById('mov-unidade-selecao').value;
                     const movementRef = doc(collection(db, 'movimentacoes'));
                     const movementData = {
                         tipo: 'entrada',
                         productId,
                         locacao: locacaoSelecionada, // Campo novo
+                        un_compra: selectedUnit || productData.un, // Salva a unidade de compra selecionada
                         data: serverTimestamp(),
                         tipo_entradaId: tipoEntradaId,
                         nf: document.getElementById('mov-nf').value,


### PR DESCRIPTION
This commit addresses a bug in the feature that allows unit selection for manual entries on the 'Movimentações' screen.

Previously, while the calculation logic correctly used the selected unit, the unit itself was not being saved with the movement record. This caused the history table to always display the product's default standard unit, regardless of the user's selection.

The following changes have been made in `js/movimentacoes.js`:
1. The form submission handler now saves the selected unit to the `un_compra` field of the movement document.
2. The `updateTable` function, which renders the history table, has been updated to prioritize displaying the `un_compra` field if it exists.

This ensures that the unit displayed in the history table accurately reflects the unit selected by the user during the entry.