### PR TITLE
Feat: Change Enter key behavior in inventory quantity field

### DIFF
--- a/js/implementacao.js
+++ b/js/implementacao.js
@@ -246,6 +246,29 @@ document.addEventListener('DOMContentLoaded', async function() {
             qtdeInput.addEventListener('input', (e) => {
                 setPendingQtde(key, e.target.value);
             });
+
+            // Add keydown event listener for Enter key
+            qtdeInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault(); // Prevent default form submission or moving to the next field in the same row
+
+                    const currentRow = e.target.closest('tr');
+                    let nextRow = currentRow.nextElementSibling;
+
+                    // Skip hidden rows
+                    while (nextRow && nextRow.style.display === 'none') {
+                        nextRow = nextRow.nextElementSibling;
+                    }
+
+                    if (nextRow) {
+                        const nextQtdeInput = nextRow.querySelector('.qtde-input');
+                        if (nextQtdeInput) {
+                            nextQtdeInput.focus();
+                            nextQtdeInput.select(); // Optional: select the content of the next input
+                        }
+                    }
+                }
+            });
         });
     }
 


### PR DESCRIPTION
This change modifies the keyboard navigation on the inventory screen. When a user presses the "Enter" key in the "Qtde" (quantity) input field, the focus now moves to the "Qtde" input field of the next row, rather than the "Valor Unit." field of the same row. This improves the user experience for rapid data entry.