### PR TITLE
feat: Corrige o cálculo do custo médio ponderado na tela de consulta

### DIFF
--- a/js/consultas.js
+++ b/js/consultas.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         const [productsSnapshot, locaisSnapshot, movementsSnapshot, conversoesSnapshot] = await Promise.all([
             getDocs(query(collection(db, 'produtos'), where("arquivado", "!=", true))),
             getDocs(collection(db, 'locais')),
-            getDocs(query(collection(db, 'movimentacoes'), where("tipo", "==", "reserva"))),
+        getDocs(query(collection(db, 'movimentacoes'))), // Busca todas as movimentações
             getDocs(collection(db, 'conversoes'))
         ]);
 
@@ -32,21 +32,47 @@ document.addEventListener('DOMContentLoaded', async function() {
             conversoesMap[doc.id] = doc.data();
         });
 
-        // 2. Calcula a quantidade total reservada para cada produto.
-        const reservasMap = {};
+        // 2. Processa todas as movimentações para calcular o custo médio e as reservas.
+        const movementsByProduct = {};
         movementsSnapshot.forEach(doc => {
             const mov = doc.data();
-            reservasMap[mov.productId] = (reservasMap[mov.productId] || 0) + mov.quantidade;
+            if (!movementsByProduct[mov.productId]) {
+                movementsByProduct[mov.productId] = [];
+            }
+            movementsByProduct[mov.productId].push(mov);
         });
 
         // 3. Mapeia os dados do produto e calcula os valores derivados.
         consolidatedData = productsSnapshot.docs.map(productDoc => {
             const product = productDoc.data();
             const productId = productDoc.id;
+            const productMovements = movementsByProduct[productId] || [];
+
+            // Ordena as movimentações por data para o cálculo correto do custo médio
+            productMovements.sort((a, b) => a.data.toMillis() - b.data.toMillis());
+
+            let totalQuantity = 0;
+            let totalCost = 0;
+            let averageCost = 0;
+            let reservedQuantity = 0;
+
+            productMovements.forEach(mov => {
+                if (mov.tipo === 'entrada' && mov.custo_total_entrada) {
+                    totalCost += mov.custo_total_entrada;
+                    totalQuantity += mov.quantidade;
+                } else if (mov.tipo === 'saida') {
+                    const currentAvgCost = totalQuantity > 0 ? totalCost / totalQuantity : 0;
+                    totalCost -= mov.quantidade * currentAvgCost;
+                    totalQuantity -= mov.quantidade;
+                } else if (mov.tipo === 'reserva') {
+                    reservedQuantity += mov.quantidade;
+                }
+            });
+
+            averageCost = totalQuantity > 0 ? totalCost / totalQuantity : 0;
 
             let estoqueAtual = 0;
             let locacaoCompleta = 'N/A';
-
             if (product.locacoes && Array.isArray(product.locacoes)) {
                 estoqueAtual = product.locacoes.reduce((acc, loc) => acc + (loc.estoque || 0), 0);
                 if (product.locacoes.length > 0) {
@@ -57,16 +83,13 @@ document.addEventListener('DOMContentLoaded', async function() {
                 }
             }
 
-            const quantidadeReservada = reservasMap[productId] || 0;
-            const valorMedio = product.valorMedio || 0;
-
             return {
                 ...product,
                 estoque: estoqueAtual,
-                cor: product.cor || '-', // Adiciona o campo cor
-                quantidadeReservada: quantidadeReservada, // Adiciona o campo de reserva
-                valorMedio: valorMedio, // Usa o valor ajustado para exibição
-                valorTotalEstoque: estoqueAtual * valorMedio,
+                cor: product.cor || '-',
+                quantidadeReservada: reservedQuantity,
+                valorMedio: averageCost,
+                valorTotalEstoque: estoqueAtual * averageCost,
                 local: locacaoCompleta
             };
         });


### PR DESCRIPTION
Ajusta a lógica de cálculo do Custo Unitário Médio na tela de consultas para refletir o custo médio ponderado móvel real do estoque.

A implementação anterior lia um valor pré-calculado e desatualizado. A nova lógica busca todo o histórico de movimentações (entradas e saídas) do produto e o processa em ordem cronológica para derivar o custo médio atual.

- As entradas atualizam o custo e a quantidade total com base no `custo_total_entrada`.
- As saídas reduzem a quantidade, e o custo da saída é baixado com base no custo médio do momento da transação.

Isso garante que o valor exibido na consulta seja preciso e esteja alinhado com as práticas de contabilidade de estoque.