### PR TITLE
fix: Corrige a ausência da locação no QR code

### DIFF
--- a/js/etiquetas.js
+++ b/js/etiquetas.js
@@ -76,8 +76,6 @@ function processarEtiquetas() {
         });
     });
 
-    // Limpa o localStorage
-    localStorage.removeItem('etiquetasParaImprimir');
 }
 
 // Inicia o processo quando a página carregar


### PR DESCRIPTION
Corrige um bug crítico onde a `locacaoId` não era incluída na URL do QR code.

O problema era uma race condition: `js/etiquetas.js` tentava ler o `localStorage` antes que `js/produtos.js` pudesse salvá-lo e, em seguida, limpava o `localStorage` prematuramente.

A correção remove a linha `localStorage.removeItem('etiquetasParaImprimir')` de `js/etiquetas.js`, garantindo que os dados persistam e estejam disponíveis quando a página de etiquetas for renderizada. Isso resolve o problema e garante que a locação correta seja sempre incluída no QR code.