### PR TITLE
feat: Relax location validation

### DIFF
--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -130,7 +130,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     function updateLocacaoRequirement() {
         const localValue = localSelect.value;
         if (localValue) {
-            locacaoSelect.required = true;
+            locacaoSelect.required = false;
         } else {
             locacaoSelect.required = false;
         }
@@ -578,10 +578,6 @@ document.addEventListener('DOMContentLoaded', async function() {
                 return;
             }
             const localSelecionado = document.getElementById('mov-local').value;
-            if (localSelecionado && !locacaoSelecionada) {
-                alert('Ao selecionar um Local, a Locação se torna obrigatória.');
-                return;
-            }
         } else { // Saída ou Transferência
              if (!productId || !locacaoSelecionada || isNaN(quantidade) || quantidade <= 0) {
                 alert('Para saídas, o produto, a locação e a quantidade são obrigatórios.');
@@ -1215,11 +1211,6 @@ document.addEventListener('DOMContentLoaded', async function() {
             const localSelect = row.cells[8].querySelector('select');
             const locacaoSelect = row.cells[9].querySelector('select');
             const codigoProduto = row.cells[0].querySelector('input').value;
-
-            if (localSelect && localSelect.value && (!locacaoSelect || !locacaoSelect.value)) {
-                alert(`Para o produto ${codigoProduto}, ao selecionar um Local, a Locação também deve ser selecionada.`);
-                return; // Interrompe a importação
-            }
         }
 
 
@@ -1389,12 +1380,11 @@ document.addEventListener('DOMContentLoaded', async function() {
         const localId = document.getElementById('modal-produto-local').value;
         const locacoes = [];
 
-        // Apenas adiciona a locação se ambos os campos estiverem preenchidos
-        if (locacao && localId) {
+        if (localId) {
             locacoes.push({
-                locacao: locacao,
+                locacao: locacao, // Se locacao estiver vazio, será salvo como ''
                 localId: localId,
-                estoque: 0 // Estoque inicial para uma nova locação é sempre 0
+                estoque: 0
             });
         } else if (locacao && !localId) {
             alert("Ao preencher a Locação, o Local também deve ser selecionado.");

--- a/js/produtos.js
+++ b/js/produtos.js
@@ -311,7 +311,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             const row = e.target.closest('.locacao-row');
             const locacaoInput = row.querySelector('.locacao-input');
             if (e.target.value) {
-                locacaoInput.required = true;
+                locacaoInput.required = false;
             } else {
                 locacaoInput.required = false;
             }
@@ -512,21 +512,23 @@ document.addEventListener('DOMContentLoaded', async function() {
             const locacao = locacaoInput.value.toUpperCase();
             const localId = localSelect.value;
 
-            if (!locacao || !localId) {
-                alert('Todas as locações devem ter um código e um local selecionado. Remova as linhas não utilizadas.');
+            if (locacao && !localId) {
+                alert('Ao preencher uma Locação, o Local também deve ser selecionado.');
                 return;
             }
 
-            if (!locacaoPattern.test(locacao)) {
+            if (locacao && !locacaoPattern.test(locacao)) {
                 alert(`O formato da locação "${locacao}" é inválido. Use o formato N-L-NN-L (ex: 1-A-02-B).`);
                 return;
             }
 
-            locacoes.push({
-                locacao: locacao,
-                localId: localId,
-                estoque: 0 // Estoque inicial é sempre 0 ao cadastrar
-            });
+            if (localId) {
+                locacoes.push({
+                    locacao: locacao,
+                    localId: localId,
+                    estoque: 0
+                });
+            }
         }
 
         const product = {


### PR DESCRIPTION
Removes the requirement to have a specific location (`locação`) when a general location (`local`) is selected.

This change affects both the product registration/editing screen and the NFe import process, allowing for more flexibility when managing product locations.

- The validation in `js/produtos.js` has been updated to allow saving a product with only a `local`.
- The validation in `js/movimentacoes.js` has been updated to allow importing products from an NFe with only a `local`.