### PR TITLE
Make dashboard charts and total cost dynamic based on toggle.

### DIFF
--- a/css/detalhe-obra-toggle.css
+++ b/css/detalhe-obra-toggle.css
@@ -1,0 +1,18 @@
+
+/* Toggle switch color for Reservas (Blue) */
+#view-toggle:checked + .slider {
+    background-color: #0d6efd !important;
+}
+
+/* Ensure container is on top */
+.toggle-container {
+    position: relative;
+    z-index: 50; /* Higher than table header (10) */
+}
+
+/* Make labels clickable */
+#toggle-label-itens,
+#toggle-label-reservas {
+    cursor: pointer;
+    user-select: none;
+}

--- a/detalhe-obra.html
+++ b/detalhe-obra.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/dashboard.css">
     <link rel="stylesheet" href="css/global-search.css">
+    <link rel="stylesheet" href="css/detalhe-obra-toggle.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
@@ -106,6 +107,18 @@
                     </div>
                 </div>
             </div>
+
+            <div class="flex justify-end">
+                <div class="toggle-container" style="margin-bottom: 0;">
+                    <span id="toggle-label-itens" style="font-weight: bold; color: #dc3545;">Itens</span>
+                    <label class="toggle-switch">
+                        <input type="checkbox" id="view-toggle">
+                        <span class="slider"></span>
+                    </label>
+                    <span id="toggle-label-reservas" style="font-weight: normal; color: #6c757d;">Reservas</span>
+                </div>
+            </div>
+
             <div class="bg-white rounded-2xl shadow-lg overflow-hidden">
                 <div class="overflow-x-auto">
                     <div class="max-h-[60vh] overflow-y-auto">

--- a/js/detalhe-obra.js
+++ b/js/detalhe-obra.js
@@ -7,8 +7,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const btnExportExcel = document.getElementById('btn-export-excel');
     const filterCodigo = document.getElementById('filter-codigo-produto');
     const filterDescricao = document.getElementById('filter-descricao-produto');
+    const viewToggle = document.getElementById('view-toggle');
+    const labelItens = document.getElementById('toggle-label-itens');
+    const labelReservas = document.getElementById('toggle-label-reservas');
 
-    let currentItens = [];
+    let currentItens = []; // Itens de Saída (Consumidos)
+    let currentReservas = []; // Itens Reservados
+    let activeDataset = []; // Dataset atualmente exibido
     let obraInfo = {};
     let charts = {}; // Para armazenar instâncias dos gráficos
 
@@ -107,11 +112,32 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function calculateFinancials(items) {
+        let total = 0;
+        const porGrupo = {};
+        const porFornecedor = {};
+
+        items.forEach(item => {
+            if (item.valorTotal) {
+                total += item.valorTotal;
+            }
+            if (item.grupo && item.valorTotal > 0) {
+                porGrupo[item.grupo] = (porGrupo[item.grupo] || 0) + item.valorTotal;
+            }
+            if (item.fornecedor && item.valorTotal > 0) {
+                porFornecedor[item.fornecedor] = (porFornecedor[item.fornecedor] || 0) + item.valorTotal;
+            }
+        });
+
+        return { total, porGrupo, porFornecedor };
+    }
+
     async function carregarDetalhesDaObra() {
         try {
-            const [obraSnap, movementsSnap, productsSnap, fornecedoresSnap, gruposSnap, aplicacoesSnap] = await Promise.all([
+            const [obraSnap, movementsSnap, reservasSnap, productsSnap, fornecedoresSnap, gruposSnap, aplicacoesSnap] = await Promise.all([
                 getDoc(doc(db, 'obras', obraId)),
                 getDocs(query(collection(db, 'movimentacoes'), where('obraId', '==', obraId), where('tipo', '==', 'saida'))),
+                getDocs(query(collection(db, 'movimentacoes'), where('obraId', '==', obraId), where('tipo', '==', 'reserva'))),
                 getDocs(collection(db, 'produtos')),
                 getDocs(collection(db, 'fornecedores')),
                 getDocs(collection(db, 'grupos')),
@@ -129,7 +155,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
             let custoTotalDaObra = 0;
             const itensUtilizados = [];
+            const itensReservados = [];
 
+            // Processar Saídas (Itens Utilizados)
             movementsSnap.forEach(movDoc => {
                 const movimentacao = movDoc.data();
                 const produto = productsMap[movimentacao.productId];
@@ -158,37 +186,58 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             });
 
+            // Processar Reservas
+            reservasSnap.forEach(movDoc => {
+                const movimentacao = movDoc.data();
+                const produto = productsMap[movimentacao.productId];
+                if (produto) {
+                    // Para reservas, usamos o valor médio atual do produto se não houver histórico,
+                    // ou mantemos zero se preferir. O usuário pediu "os valores mais dos itens".
+                    // Assumindo valorMedio do produto atual se não salvo na movimentação.
+                    // Reservas geralmente não tem valorMedioHistorico salvo no momento da reserva (depende da implementação).
+                    // Vou tentar usar valorMedioHistorico se existir, senão o do produto.
+                    const valorMedio = movimentacao.valorMedioHistorico || produto.valorMedio || 0;
+                    const valorTotalItem = movimentacao.quantidade * valorMedio;
+
+                    const fornecedor = produto.fornecedorId ? (fornecedoresMap[produto.fornecedorId]?.nome || 'N/A') : 'N/A';
+                    const grupo = produto.grupoId ? (gruposMap[produto.grupoId]?.nome || 'N/A') : 'N/A';
+                    const aplicacoes = (produto.aplicacaoIds || []).map(id => aplicacoesMap[id]?.nome || '').filter(Boolean).join(', ') || 'N/A';
+
+                    itensReservados.push({
+                        codigo: produto.codigo,
+                        descricao: produto.descricao,
+                        un: produto.un,
+                        cor: produto.cor || '-',
+                        fornecedor,
+                        grupo,
+                        aplicacoes,
+                        qtde: movimentacao.quantidade,
+                        observacao: movimentacao.observacao || '-',
+                        valorMedio: valorMedio,
+                        valorTotal: valorTotalItem
+                    });
+                }
+            });
+
             currentItens = itensUtilizados;
+            currentReservas = itensReservados;
+
             const obraData = obraSnap.data();
             obraInfo = {
                 codigo: obraData.codigo || 'S/C',
                 nome: obraData.nome
             };
 
-            const custoPorGrupo = {};
-            const custoPorFornecedor = {};
-            itensUtilizados.forEach(item => {
-                if (item.grupo && item.valorTotal > 0) {
-                    custoPorGrupo[item.grupo] = (custoPorGrupo[item.grupo] || 0) + item.valorTotal;
-                }
-                if (item.fornecedor && item.valorTotal > 0) {
-                    custoPorFornecedor[item.fornecedor] = (custoPorFornecedor[item.fornecedor] || 0) + item.valorTotal;
-                }
-            });
-
             document.getElementById('obra-titulo').textContent = `${obraInfo.codigo} - ${obraInfo.nome}`;
-            const custoTotalElement = document.getElementById('obra-custo-total');
-            if (custoTotalElement) {
-                custoTotalElement.innerHTML = `Custo Total: <span class="font-semibold text-blue-600">${custoTotalDaObra.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</span>`;
-            }
 
             const orcamentoElement = document.getElementById('obra-orcamento');
             if (orcamentoElement && obraData.orcamento) {
                 orcamentoElement.innerHTML = `Orçamento: <span class="font-semibold" style="color: red;">${parseFloat(obraData.orcamento).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</span>`;
             }
 
-            renderTabelaItens(itensUtilizados);
-            renderCharts(custoPorGrupo, custoPorFornecedor);
+            // Define o dataset ativo inicial com base no estado do toggle e atualiza UI (incluindo dashboard)
+            activeDataset = viewToggle.checked ? currentReservas : currentItens;
+            updateToggleUI();
 
         } catch (error) {
             console.error("Erro ao carregar detalhes da obra:", error);
@@ -228,7 +277,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function applyFilters() {
         const codigoFilter = filterCodigo.value.toLowerCase();
         const descricaoFilter = filterDescricao.value.toLowerCase();
-        const filteredItens = currentItens.filter(item => {
+        const filteredItens = activeDataset.filter(item => {
             const codigoMatch = item.codigo.toLowerCase().includes(codigoFilter);
             const descricaoMatch = item.descricao.toLowerCase().includes(descricaoFilter);
             return codigoMatch && descricaoMatch;
@@ -236,12 +285,60 @@ document.addEventListener('DOMContentLoaded', () => {
         renderTabelaItens(filteredItens);
     }
 
+    function updateToggleUI() {
+        if (viewToggle.checked) {
+            // Modo Reservas
+            labelItens.style.fontWeight = 'normal';
+            labelItens.style.color = '#6c757d';
+            labelReservas.style.fontWeight = 'bold';
+            labelReservas.style.color = '#0d6efd'; // Azul
+            activeDataset = currentReservas;
+        } else {
+            // Modo Itens (Saída)
+            labelItens.style.fontWeight = 'bold';
+            labelItens.style.color = '#dc3545'; // Vermelho
+            labelReservas.style.fontWeight = 'normal';
+            labelReservas.style.color = '#6c757d';
+            activeDataset = currentItens;
+        }
+
+        const financials = calculateFinancials(activeDataset);
+
+        // Update Total Cost
+        const custoTotalElement = document.getElementById('obra-custo-total');
+        if (custoTotalElement) {
+             custoTotalElement.innerHTML = `Custo Total: <span class="font-semibold text-blue-600">${financials.total.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</span>`;
+        }
+
+        // Update Charts
+        renderCharts(financials.porGrupo, financials.porFornecedor);
+
+        applyFilters(); // Re-renderiza com filtros atuais
+    }
+
+    viewToggle.addEventListener('change', updateToggleUI);
+
+    // Make text labels clickable
+    labelItens.addEventListener('click', () => {
+        if (viewToggle.checked) {
+            viewToggle.checked = false;
+            updateToggleUI();
+        }
+    });
+
+    labelReservas.addEventListener('click', () => {
+        if (!viewToggle.checked) {
+            viewToggle.checked = true;
+            updateToggleUI();
+        }
+    });
+
     function exportToExcel() {
-        if (currentItens.length === 0) {
+        if (activeDataset.length === 0) {
             alert("Não há itens para exportar.");
             return;
         }
-        const dataForExport = currentItens.map(item => ({
+        const dataForExport = activeDataset.map(item => ({
             'Código': item.codigo, 'Descrição': item.descricao, 'UN': item.un, 'Cor': item.cor,
             'Fornecedor': item.fornecedor, 'Grupo': item.grupo, 'Aplicações': item.aplicacoes,
             'Qtde': item.qtde, 'Observação': item.observacao, 'Valor Médio': item.valorMedio,
@@ -251,12 +348,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const workbook = XLSX.utils.book_new();
         XLSX.utils.sheet_add_aoa(worksheet, [[`Código da Obra: ${obraInfo.codigo}`]], { origin: 'A1' });
         XLSX.utils.sheet_add_aoa(worksheet, [[`Nome da Obra: ${obraInfo.nome}`]], { origin: 'A2' });
-        XLSX.utils.sheet_add_json(worksheet, dataForExport, { origin: 'A4', skipHeader: false });
+        const tipoListagem = viewToggle.checked ? "Reservas" : "Itens Utilizados";
+        XLSX.utils.sheet_add_aoa(worksheet, [[`Listagem: ${tipoListagem}`]], { origin: 'A3' });
+        XLSX.utils.sheet_add_json(worksheet, dataForExport, { origin: 'A5', skipHeader: false });
         worksheet['!cols'] = [
             { wch: 15 }, { wch: 40 }, { wch: 8 }, { wch: 15 }, { wch: 25 },
             { wch: 25 }, { wch: 30 }, { wch: 10 }, { wch: 40 }, { wch: 15 }, { wch: 15 }
         ];
-        XLSX.writeFile(workbook, `Itens_Obra_${obraInfo.codigo}_${obraInfo.nome}.xlsx`);
+        XLSX.writeFile(workbook, `${tipoListagem}_Obra_${obraInfo.codigo}_${obraInfo.nome}.xlsx`);
     }
 
     filterCodigo.addEventListener('input', applyFilters);


### PR DESCRIPTION
- Refactored `js/detalhe-obra.js` to extract financial calculations into `calculateFinancials`.
- Updated `updateToggleUI` to recalculate total cost and update charts (group/supplier) whenever the dataset switches between 'Itens' and 'Reservas'.
- Removed redundant initialization logic in `carregarDetalhesDaObra` in favor of calling `updateToggleUI` for the initial render.
- Ensures the 'Resumo Financeiro' and 'Custo Total' accurately reflect the currently visible data.