### PR TITLE
I've fixed the stock loss issue that occurred during location renames…

### DIFF
--- a/js/produtos.js
+++ b/js/produtos.js
@@ -231,12 +231,21 @@ document.addEventListener('DOMContentLoaded', async function() {
 
     // --- LÓGICA PARA GERENCIAR LOCAÇÕES DINÂMICAS ---
 
-    const addLocacaoRow = (locacao = '', localId = '') => {
+    const addLocacaoRow = (locacao = '', localId = '', originalLocacao = null, originalLocalId = null) => {
         const row = document.createElement('div');
         row.className = 'locacao-row';
         row.style.display = 'flex';
         row.style.gap = '10px';
         row.style.alignItems = 'center';
+
+        // Armazena os valores originais para preservar o estoque em caso de edição
+        // Garante que undefined não seja gravado como string "undefined"
+        if (originalLocacao !== null && originalLocacao !== undefined) {
+             row.dataset.originalLocacao = originalLocacao;
+        }
+        if (originalLocalId !== null && originalLocalId !== undefined) {
+             row.dataset.originalLocalId = originalLocalId;
+        }
 
         const locacaoInput = document.createElement('input');
         locacaoInput.type = 'text';
@@ -513,6 +522,10 @@ document.addEventListener('DOMContentLoaded', async function() {
             const locacao = locacaoInput.value.toUpperCase();
             const localId = localSelect.value;
 
+            // Recupera as chaves originais salvas no elemento DOM
+            const originalLocacao = row.dataset.originalLocacao;
+            const originalLocalId = row.dataset.originalLocalId;
+
             if (locacao && !localId) {
                 alert('Ao preencher uma Locação, o Local também deve ser selecionado.');
                 return;
@@ -527,7 +540,10 @@ document.addEventListener('DOMContentLoaded', async function() {
                 locacoes.push({
                     locacao: locacao,
                     localId: localId,
-                    estoque: 0
+                    estoque: 0, // Será atualizado abaixo se for edição
+                    // Salva as chaves originais no objeto temporário para uso na lógica de preservação
+                    _originalLocacao: originalLocacao,
+                    _originalLocalId: originalLocalId
                 });
             }
         }
@@ -548,19 +564,57 @@ document.addEventListener('DOMContentLoaded', async function() {
 
         try {
             if (productId) {
-                // Ao atualizar, precisamos manter o estoque existente. Esta lógica será mais complexa.
-                // Por enquanto, vamos apenas setar, mas o ideal é uma transação que preserve o estoque.
-                // Esta parte será melhorada na etapa de migração e movimentação.
+                // Ao atualizar, precisamos manter o estoque existente.
                 const originalProduct = productsData.find(p => p.id === productId)?.data;
+
                 if (originalProduct && originalProduct.locacoes) {
+                    // Mapeia as novas locações preservando o estoque das originais correspondentes
                     product.locacoes = locacoes.map(novaLoc => {
-                        const existente = originalProduct.locacoes.find(antiga => antiga.locacao === novaLoc.locacao && antiga.localId === novaLoc.localId);
-                        return existente ? existente : novaLoc; // Mantém a locação existente com seu estoque
+                        let estoque = 0;
+
+                        // 1. Tenta encontrar pela chave ORIGINAL (se o usuário editou uma linha existente)
+                        // Isso permite renomear a locação mantendo o estoque (Move o estoque)
+                        if (novaLoc._originalLocacao !== undefined && novaLoc._originalLocalId !== undefined) {
+                            const originalMatch = originalProduct.locacoes.find(antiga =>
+                                String(antiga.locacao || '') === String(novaLoc._originalLocacao || '') &&
+                                String(antiga.localId || '') === String(novaLoc._originalLocalId || '')
+                            );
+                            if (originalMatch) {
+                                estoque = originalMatch.estoque || 0;
+                            }
+                        }
+                        // 2. Fallback: Se não tem chave original (ex: apagou e criou de novo igual),
+                        // tenta casar pelo nome atual para não zerar estoque acidentalmente se a linha for recriada
+                        else {
+                            const matchByName = originalProduct.locacoes.find(antiga =>
+                                antiga.locacao === novaLoc.locacao &&
+                                antiga.localId === novaLoc.localId
+                            );
+                            if (matchByName) {
+                                estoque = matchByName.estoque || 0;
+                            }
+                        }
+
+                        // Remove as propriedades temporárias antes de salvar
+                        const { _originalLocacao, _originalLocalId, ...locData } = novaLoc;
+                        return { ...locData, estoque: estoque };
                     });
+                } else {
+                    // Se não tinha locações antes, limpa as propriedades temporárias
+                     product.locacoes = locacoes.map(l => {
+                        const { _originalLocacao, _originalLocalId, ...rest } = l;
+                        return rest;
+                     });
                 }
+
                 await setDoc(doc(db, 'produtos', productId), product, { merge: true });
                 alert('Produto atualizado com sucesso!');
             } else {
+                // Remove propriedades temporárias para novos produtos também
+                 product.locacoes = locacoes.map(l => {
+                    const { _originalLocacao, _originalLocalId, ...rest } = l;
+                    return rest;
+                 });
                 await addDoc(collection(db, 'produtos'), product);
                 alert('Produto cadastrado com sucesso!');
             }
@@ -766,7 +820,8 @@ document.addEventListener('DOMContentLoaded', async function() {
             // Preenche as locações dinâmicas
             if (product.data.locacoes && Array.isArray(product.data.locacoes)) {
                 product.data.locacoes.forEach(loc => {
-                    addLocacaoRow(loc.locacao, loc.localId);
+                    // Passa também os valores originais para rastreamento
+                    addLocacaoRow(loc.locacao, loc.localId, loc.locacao, loc.localId);
                 });
             }
 


### PR DESCRIPTION
… by implementing more robust tracking.

Here are the details of the update:

Updated `js/produtos.js` to preserve stock quantities when editing product locations.
- Modified `addLocacaoRow` to track `originalLocacao` and `originalLocalId` using data attributes, ensuring `undefined` values are not written as strings.
- Updated the form handler to use robust string comparison (`String()`) when matching original locations to preserved stock, handling potential type mismatches (e.g., Number vs String) and `undefined`/empty string edge cases.

This prevents the system from failing to find the original location during a rename operation, which previously caused the stock to reset to 0.