### PR TITLE
Corrige importação NF-e e protege processo em andamento

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,8 @@
 import { db } from './firebase-config.js';
+import { instalarProtecaoImportacaoNFe } from './nfe-import-guard.js';
 
 document.addEventListener('DOMContentLoaded', function() {
     console.log("Sistema de Controle de Estoque iniciado.");
+    instalarProtecaoImportacaoNFe();
     // Lógica comum a todas as páginas, como manipulação do menu, pode ser adicionada aqui.
 });

--- a/js/movimentacoes.js
+++ b/js/movimentacoes.js
@@ -3,6 +3,25 @@ function showInfoModal(message) {
     document.getElementById('info-modal').style.display = 'block';
 }
 
+function normalizarUnidade(unidade) {
+    return String(unidade || '')
+        .trim()
+        .toUpperCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/\./g, '')
+        .replace(/\s+/g, '');
+}
+
+function unidadeExigeQuantidadeInteira(unidade) {
+    const unidadeNormalizada = normalizarUnidade(unidade);
+    return unidadeNormalizada === 'PC' || unidadeNormalizada === 'UN';
+}
+
+function quantidadeEhInteira(quantidade) {
+    return Number.isFinite(quantidade) && Math.abs(quantidade - Math.round(quantidade)) < 1e-9;
+}
+
 import { db } from './firebase-config.js';
 import { collection, addDoc, getDocs, onSnapshot, runTransaction, doc, serverTimestamp, query, where, getDoc, orderBy } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js";
 import { calcularCustoMedioAposEntrada, normalizarTexto, obterDataEfetivaMovimento, obterTimestampMillis, recalcularCustoMedioProduto as recalcularCustoMedioProdutoCentral } from './custo-medio.js';
@@ -1928,18 +1947,34 @@ document.addEventListener('DOMContentLoaded', async function() {
 
                 const produto = productsMap[productId];
                 const quantidadeInformada = parseFloat(row.cells[3].querySelector('input').value);
+                const unidadeCompraXml = row.dataset.unidadeCompra;
                 let quantidadeParaEstoque = quantidadeInformada;
+                let unidadeEstoque = produto.un || unidadeCompraXml || '';
 
-                // Lógica de Conversão
+                // A regra de conversão só se aplica quando a unidade informada na NF-e
+                // corresponde à unidade de compra configurada. Se a NF-e já vier na
+                // unidade padrão (ex.: M2), a quantidade deve entrar como informada.
                 if (produto.conversaoId) {
                     const regra = configData.conversoes[produto.conversaoId];
                     if (regra) {
-                        const fator_qtd_compra = parseFloat(String(regra.qtd_compra).replace(',', '.'));
-                        const fator_qtd_padrao = parseFloat(String(regra.qtd_padrao).replace(',', '.'));
-                        if (fator_qtd_compra > 0) {
-                            quantidadeParaEstoque = (quantidadeInformada / fator_qtd_compra) * fator_qtd_padrao;
+                        const unidadeCompraRegra = normalizarUnidade(regra.medida_compra);
+                        const unidadeCompraNfe = normalizarUnidade(unidadeCompraXml);
+
+                        if (unidadeCompraRegra && unidadeCompraNfe === unidadeCompraRegra) {
+                            const fator_qtd_compra = parseFloat(String(regra.qtd_compra).replace(',', '.'));
+                            const fator_qtd_padrao = parseFloat(String(regra.qtd_padrao).replace(',', '.'));
+                            if (fator_qtd_compra > 0) {
+                                quantidadeParaEstoque = (quantidadeInformada / fator_qtd_compra) * fator_qtd_padrao;
+                                unidadeEstoque = regra.medida_padrao || unidadeEstoque;
+                            }
                         }
                     }
+                }
+
+                // Evita que imprecisão de ponto flutuante transforme, por exemplo,
+                // 3 unidades em 2.999999999 e dispare uma correção indevida.
+                if (quantidadeEhInteira(quantidadeParaEstoque)) {
+                    quantidadeParaEstoque = Math.round(quantidadeParaEstoque);
                 }
 
                 const itemData = {
@@ -1953,11 +1988,14 @@ document.addEventListener('DOMContentLoaded', async function() {
                     frete: parseFloat(row.cells[7].querySelector('input').value) || 0,
                     localSelecionado: row.cells[8].querySelector('select').value,
                     locacaoSelecionada: row.cells[9].querySelector('select').value,
-                    unidadeCompra: row.dataset.unidadeCompra,
+                    unidadeCompra: unidadeCompraXml,
+                    unidadeEstoque: unidadeEstoque,
                     nItem: row.dataset.nItem
                 };
 
-                if (quantidadeParaEstoque % 1 !== 0) {
+                // Quantidade inteira só é obrigatória para unidades discretas de estoque.
+                // M2 e outras unidades contínuas podem receber valores fracionados normalmente.
+                if (unidadeExigeQuantidadeInteira(unidadeEstoque) && !quantidadeEhInteira(quantidadeParaEstoque)) {
                     itemData.quantidadeCalculada = quantidadeParaEstoque;
                     itensComProblema.push(itemData);
                 } else {

--- a/js/nfe-import-guard.js
+++ b/js/nfe-import-guard.js
@@ -1,0 +1,149 @@
+function elementoVisivel(elemento) {
+    return Boolean(elemento) && window.getComputedStyle(elemento).display !== 'none';
+}
+
+export function instalarProtecaoImportacaoNFe() {
+    const xmlModal = document.getElementById('xml-import-modal');
+    const xmlModalClose = document.getElementById('xml-modal-close');
+    const xmlLoader = document.getElementById('xml-import-loader');
+    const btnConfirmarImportacao = document.getElementById('btn-confirmar-xml-import');
+    const modalCorrecao = document.getElementById('correcao-fracionada-modal');
+    const btnConfirmarCorrecoes = document.getElementById('btn-confirmar-correcoes');
+    const modalCorrecaoClose = document.getElementById('correcao-modal-close');
+
+    if (!xmlModal || !xmlLoader || !btnConfirmarImportacao) return;
+
+    let fase = 'idle';
+    let protegido = false;
+
+    const estilosOriginais = new Map();
+    [xmlModalClose, modalCorrecaoClose].filter(Boolean).forEach(elemento => {
+        estilosOriginais.set(elemento, {
+            pointerEvents: elemento.style.pointerEvents,
+            opacity: elemento.style.opacity,
+            cursor: elemento.style.cursor
+        });
+    });
+
+    function atualizarFechamentoVisual(bloqueado) {
+        [xmlModalClose, modalCorrecaoClose].filter(Boolean).forEach(elemento => {
+            const original = estilosOriginais.get(elemento) || {};
+            if (bloqueado) {
+                elemento.style.pointerEvents = 'none';
+                elemento.style.opacity = '0.35';
+                elemento.style.cursor = 'not-allowed';
+                elemento.setAttribute('aria-disabled', 'true');
+                elemento.title = 'Aguarde a importação terminar';
+            } else {
+                elemento.style.pointerEvents = original.pointerEvents || '';
+                elemento.style.opacity = original.opacity || '';
+                elemento.style.cursor = original.cursor || '';
+                elemento.removeAttribute('aria-disabled');
+                elemento.removeAttribute('title');
+            }
+        });
+    }
+
+    function definirProtecao(ativa) {
+        protegido = ativa;
+        atualizarFechamentoVisual(ativa);
+        document.documentElement.toggleAttribute('data-importacao-nfe-em-andamento', ativa);
+    }
+
+    function mostrarAvisoNoLoader() {
+        const mensagem = xmlLoader.querySelector('.loader-message');
+        if (!mensagem) return;
+
+        if (!mensagem.dataset.textoOriginal) {
+            mensagem.dataset.textoOriginal = mensagem.textContent || '';
+        }
+
+        mensagem.textContent = 'Importação em andamento. Aguarde a conclusão antes de sair.';
+    }
+
+    function sincronizarEstado() {
+        const correcaoVisivel = elementoVisivel(modalCorrecao);
+        const importacaoInicialSinalizada = btnConfirmarImportacao.disabled && elementoVisivel(xmlLoader);
+
+        if (fase === 'idle' && importacaoInicialSinalizada && !correcaoVisivel) {
+            fase = 'initial';
+            definirProtecao(true);
+            mostrarAvisoNoLoader();
+            return;
+        }
+
+        if (fase === 'initial' && correcaoVisivel) {
+            // A primeira etapa terminou. Neste ponto o sistema está aguardando
+            // a decisão do usuário no modal de correção e não há gravação em andamento.
+            fase = 'correction';
+            definirProtecao(false);
+            return;
+        }
+
+        if (fase === 'initial' && !btnConfirmarImportacao.disabled) {
+            fase = 'idle';
+            definirProtecao(false);
+        }
+    }
+
+    const observer = new MutationObserver(sincronizarEstado);
+    observer.observe(btnConfirmarImportacao, { attributes: true, attributeFilter: ['disabled'] });
+    observer.observe(xmlLoader, { attributes: true, attributeFilter: ['style', 'class'] });
+    if (modalCorrecao) {
+        observer.observe(modalCorrecao, { attributes: true, attributeFilter: ['style', 'class'] });
+    }
+
+    // O processamento das correções também grava item por item. Ativa a mesma
+    // proteção antes de o handler original começar a executar.
+    if (btnConfirmarCorrecoes) {
+        btnConfirmarCorrecoes.addEventListener('click', () => {
+            if (fase !== 'correction') return;
+            fase = 'correction-processing';
+            definirProtecao(true);
+            mostrarAvisoNoLoader();
+        }, true);
+    }
+
+    // Impede fechar o modal, clicar no fundo para fechá-lo ou navegar pelos links
+    // internos enquanto existe gravação de NF-e em andamento.
+    document.addEventListener('click', event => {
+        if (!protegido) return;
+
+        const alvo = event.target;
+        const clicouFecharXml = xmlModalClose && (alvo === xmlModalClose || xmlModalClose.contains(alvo));
+        const clicouFecharCorrecao = modalCorrecaoClose && (alvo === modalCorrecaoClose || modalCorrecaoClose.contains(alvo));
+        const clicouFundoXml = alvo === xmlModal;
+        const clicouFundoCorrecao = modalCorrecao && alvo === modalCorrecao;
+        const link = alvo instanceof Element ? alvo.closest('a[href]') : null;
+
+        if (clicouFecharXml || clicouFecharCorrecao || clicouFundoXml || clicouFundoCorrecao || link) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            mostrarAvisoNoLoader();
+        }
+    }, true);
+
+    document.addEventListener('keydown', event => {
+        if (!protegido) return;
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            mostrarAvisoNoLoader();
+        }
+    }, true);
+
+    window.addEventListener('beforeunload', event => {
+        if (!protegido) return;
+
+        // O fluxo original conclui as correções ocultando o modal e, em seguida,
+        // chama location.reload(). Nesse único caso a recarga é parte da conclusão
+        // normal e deve passar sem exibir um aviso falso.
+        const recargaFinalCorrecao = fase === 'correction-processing' && modalCorrecao && !elementoVisivel(modalCorrecao);
+        if (recargaFinalCorrecao) return;
+
+        event.preventDefault();
+        event.returnValue = '';
+    });
+
+    sincronizarEstado();
+}


### PR DESCRIPTION
## O que foi corrigido

### Unidades e conversão
- A importação de NF-e só aplica conversão quando a unidade comercial (`uCom`) do XML corresponde à `medida_compra` configurada.
- `PC`, `PÇ` e `UN` continuam exigindo quantidade final inteira.
- `M2` e outras unidades contínuas aceitam quantidade fracionada normalmente.
- Normalização de unidade evita diferenças de acento, caixa, espaços e pontuação.
- Tolerância numérica evita que valores como `2.999999999` sejam tratados como quantidade fracionada.

### Segurança durante a importação
- Enquanto há gravação de itens da NF-e em andamento, o X do modal fica desativado.
- Clique no fundo do modal e tecla `Esc` não fecham o processo durante a gravação.
- Links internos de navegação são bloqueados enquanto a importação está gravando.
- Atualizar, voltar, fechar a aba ou fechar a janela dispara a proteção nativa `beforeunload` do navegador.
- O mesmo bloqueio é reativado durante a gravação dos itens corrigidos.
- A proteção é retirada quando a etapa de gravação termina, sem bloquear a recarga normal de conclusão.

## Integridade dos dados
Cada item continua sendo gravado pela transação Firestore já existente, que atualiza estoque/custo e cria a movimentação de forma atômica. A proteção adicionada não altera a regra de estoque nem a estrutura do banco.

## Arquivos
- `js/movimentacoes.js`: correção de unidade/conversão.
- `js/nfe-import-guard.js`: módulo dedicado à proteção da importação em andamento.
- `js/main.js`: inicialização da proteção.

## Validação
- Sintaxe dos dois módulos alterados/novos verificada com `node --check`.
- IDs usados pela proteção conferidos no `movimentacoes.html`.
- Diff contra `feat/qrcode-estoque`: 3 arquivos, sem alterações de schema ou banco.
- O repositório não possui workflow/status check associado a esta branch.